### PR TITLE
fix auto scaling issue

### DIFF
--- a/backend/interfaces/nomadcluster/client_test.go
+++ b/backend/interfaces/nomadcluster/client_test.go
@@ -1,0 +1,136 @@
+package nomadcluster
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/nomad-ops/nomad-ops/backend/domain"
+	"github.com/nomad-ops/nomad-ops/backend/utils/log"
+)
+
+// need a running nomad cluster to test this
+// set NOMAD_ADDR and NOMAD_TOKEN env vars if needed
+func Test_IgnoreAutoscalingOptions_Horizontal(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping test")
+		return
+	}
+	ctx := context.Background()
+	logger := log.NewSimpleLogger(true, "Test")
+
+	//os.Setenv("NOMAD_ADDR", "http://172.31.101.5:4646")
+
+	nomadClient, err := CreateClient(ctx, logger, ClientConfig{
+		NomadToken: "",
+	})
+	if err != nil {
+		t.Fatalf("Error creating nomad client: %v", err)
+	}
+
+	// prepare test data
+	source := &domain.Source{
+		ID:              "test",
+		Name:            "test",
+		Branch:          "main",
+		Namespace:       "test",
+		CreateNamespace: true,
+	}
+	b, err := os.ReadFile("testdata/nginx_horizontal_scaling.hcl")
+	if err != nil {
+		t.Fatalf("Error reading job file: %v", err)
+	}
+
+	jobInfo, err := nomadClient.ParseJob(ctx, string(b))
+	if err != nil {
+		t.Fatalf("Error parsing job: %v", err)
+	}
+	// simulate a scaling by setting the count to 2
+	count := 2
+	jobInfo.Job.TaskGroups[0].Count = &count
+
+	// Prepare environment
+
+	// deploy job
+	scaledJob, err := nomadClient.UpdateJob(ctx, source, jobInfo, false)
+	if err != nil {
+		t.Fatalf("Error updating job: %v", err)
+	}
+	if !scaledJob.Updated {
+		t.Fatalf("Job not updated")
+	}
+
+	// we now have a job with count 2 running
+	// now we will update the job with count 1 => it should be a no-op
+	count = 1
+	jobInfo.Job.TaskGroups[0].Count = &count
+	info, err := nomadClient.UpdateJob(ctx, source, jobInfo, false)
+	if err != nil {
+		t.Fatalf("Error updating job: %v", err)
+	}
+	if info.Updated {
+		t.Fatalf("Job updated")
+	}
+}
+
+func Test_IgnoreAutoscalingOptions_Vertical(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping test")
+		return
+	}
+	ctx := context.Background()
+	logger := log.NewSimpleLogger(true, "Test")
+
+	os.Setenv("NOMAD_ADDR", "http://172.31.101.5:4646")
+
+	nomadClient, err := CreateClient(ctx, logger, ClientConfig{
+		NomadToken: "",
+	})
+	if err != nil {
+		t.Fatalf("Error creating nomad client: %v", err)
+	}
+
+	// prepare test data
+	source := &domain.Source{
+		ID:              "test",
+		Name:            "test",
+		Branch:          "main",
+		Namespace:       "test",
+		CreateNamespace: true,
+	}
+	b, err := os.ReadFile("testdata/nginx_vertical_scaling.hcl")
+	if err != nil {
+		t.Fatalf("Error reading job file: %v", err)
+	}
+
+	jobInfo, err := nomadClient.ParseJob(ctx, string(b))
+	if err != nil {
+		t.Fatalf("Error parsing job: %v", err)
+	}
+	// simulate a vertical scaling by setting the cpu to 6000
+	cpu := 600
+	jobInfo.Job.TaskGroups[0].Tasks[0].Resources.CPU = &cpu
+
+	// Prepare environment
+
+	// deploy job
+	scaledJob, err := nomadClient.UpdateJob(ctx, source, jobInfo, false)
+	if err != nil {
+		t.Fatalf("Error updating job: %v", err)
+	}
+	if !scaledJob.Updated {
+		t.Fatalf("Job not updated")
+	}
+
+	// we now have a task with 600 CPU running
+	// now we will update the job with CPU 500 => it should be a no-op
+	cpu = 500
+	jobInfo.Job.TaskGroups[0].Tasks[0].Resources.CPU = &cpu
+	info, err := nomadClient.UpdateJob(ctx, source, jobInfo, false)
+	if err != nil {
+		t.Fatalf("Error updating job: %v", err)
+	}
+	if info.Updated {
+		t.Fatalf("Job updated")
+	}
+}

--- a/backend/interfaces/nomadcluster/testdata/nginx.hcl
+++ b/backend/interfaces/nomadcluster/testdata/nginx.hcl
@@ -1,0 +1,97 @@
+# There can only be a single job definition per file.
+# Create a job with ID and Name 'example'
+job "nginx" {
+	# Run the job in the global region, which is the default.
+	# region = "global"
+
+	# Specify the datacenters within the region this job can run in.
+	datacenters = ["dc1"]
+
+	# Service type jobs optimize for long-lived services. This is
+	# the default but we can change to batch for short-lived tasks.
+	# type = "service"
+
+	# Priority controls our access to resources and scheduling priority.
+	# This can be 1 to 100, inclusively, and defaults to 50.
+	# priority = 50
+
+	# Restrict our job to only linux. We can specify multiple
+	# constraints as needed.
+	constraint {
+		attribute = "${attr.kernel.name}"
+		value = "linux"
+	}
+
+	# Configure the job to do rolling updates
+	update {
+		# Stagger updates every 10 seconds
+		stagger = "10s"
+
+		# Update a single task at a time
+		max_parallel = 1
+	}
+
+	# Create a 'cache' group. Each task in the group will be
+	# scheduled onto the same machine.
+	group "cache" {
+		# Control the number of instances of this groups.
+		# Defaults to 1
+		# count = 1
+
+		# Configure the restart policy for the task group. If not provided, a
+		# default is used based on the job type.
+		restart {
+			# The number of attempts to run the job within the specified interval.
+			attempts = 10
+			interval = "5m"
+			
+			# A delay between a task failing and a restart occurring.
+			delay = "25s"
+
+			# Mode controls what happens when a task has restarted "attempts"
+			# times within the interval. "delay" mode delays the next restart
+			# till the next interval. "fail" mode does not restart the task if
+			# "attempts" has been hit within the interval.
+			mode = "delay"
+		}
+
+		# Define a task to run
+		task "nginx" {
+			# Use Docker to run the task.
+			driver = "docker"
+
+			# Configure Docker driver with the image
+			config {
+				image = "nginx:latest"
+			}
+
+			# We must specify the resources required for
+			# this task to ensure it runs on a machine with
+			# enough capacity.
+			resources {
+				cpu = 500 # 500 Mhz
+				memory = 256 # 256MB
+			}
+
+			# The artifact block can be specified one or more times to download
+			# artifacts prior to the task being started. This is convenient for
+			# shipping configs or data needed by the task.
+			# artifact {
+			#	  source = "http://foo.com/artifact.tar.gz"
+			#	  options {
+			#	      checksum = "md5:c4aa853ad2215426eb7d70a21922e794"
+			#     }
+			# }
+			
+			# Specify configuration related to log rotation
+			# logs {
+			#     max_files = 10
+			#	  max_file_size = 15
+			# }
+			 
+			# Controls the timeout between signalling a task it will be killed
+			# and killing the task. If not set a default is used.
+			# kill_timeout = "20s"
+		}
+	}
+}

--- a/backend/interfaces/nomadcluster/testdata/nginx_horizontal_scaling.hcl
+++ b/backend/interfaces/nomadcluster/testdata/nginx_horizontal_scaling.hcl
@@ -1,0 +1,107 @@
+# There can only be a single job definition per file.
+# Create a job with ID and Name 'example'
+job "nginx-horizontal-scaling" {
+	# Run the job in the global region, which is the default.
+	# region = "global"
+
+	# Specify the datacenters within the region this job can run in.
+	datacenters = ["dc1"]
+
+	# Service type jobs optimize for long-lived services. This is
+	# the default but we can change to batch for short-lived tasks.
+	# type = "service"
+
+	# Priority controls our access to resources and scheduling priority.
+	# This can be 1 to 100, inclusively, and defaults to 50.
+	# priority = 50
+
+	# Restrict our job to only linux. We can specify multiple
+	# constraints as needed.
+	constraint {
+		attribute = "${attr.kernel.name}"
+		value = "linux"
+	}
+
+	# Configure the job to do rolling updates
+	update {
+		# Stagger updates every 10 seconds
+		stagger = "10s"
+
+		# Update a single task at a time
+		max_parallel = 1
+	}
+
+	# Create a 'cache' group. Each task in the group will be
+	# scheduled onto the same machine.
+	group "cache" {
+		# Control the number of instances of this groups.
+		# Defaults to 1
+		# count = 1
+
+		# Configure the restart policy for the task group. If not provided, a
+		# default is used based on the job type.
+		restart {
+			# The number of attempts to run the job within the specified interval.
+			attempts = 10
+			interval = "5m"
+			
+			# A delay between a task failing and a restart occurring.
+			delay = "25s"
+
+			# Mode controls what happens when a task has restarted "attempts"
+			# times within the interval. "delay" mode delays the next restart
+			# till the next interval. "fail" mode does not restart the task if
+			# "attempts" has been hit within the interval.
+			mode = "delay"
+		}
+
+		scaling {
+			enabled = true
+			min     = 0
+			max     = 10
+
+			policy {
+				# ...
+			}
+		}
+
+		# Define a task to run
+		task "nginx" {
+			# Use Docker to run the task.
+			driver = "docker"
+
+			# Configure Docker driver with the image
+			config {
+				image = "nginx:latest"
+			}
+
+			# We must specify the resources required for
+			# this task to ensure it runs on a machine with
+			# enough capacity.
+			resources {
+				cpu = 500 # 500 Mhz
+				memory = 256 # 256MB
+			}
+
+			# The artifact block can be specified one or more times to download
+			# artifacts prior to the task being started. This is convenient for
+			# shipping configs or data needed by the task.
+			# artifact {
+			#	  source = "http://foo.com/artifact.tar.gz"
+			#	  options {
+			#	      checksum = "md5:c4aa853ad2215426eb7d70a21922e794"
+			#     }
+			# }
+			
+			# Specify configuration related to log rotation
+			# logs {
+			#     max_files = 10
+			#	  max_file_size = 15
+			# }
+			 
+			# Controls the timeout between signalling a task it will be killed
+			# and killing the task. If not set a default is used.
+			# kill_timeout = "20s"
+		}
+	}
+}

--- a/backend/interfaces/nomadcluster/testdata/nginx_vertical_scaling.hcl
+++ b/backend/interfaces/nomadcluster/testdata/nginx_vertical_scaling.hcl
@@ -1,0 +1,117 @@
+# There can only be a single job definition per file.
+# Create a job with ID and Name 'example'
+job "nginx-vertical-scaling" {
+	# Run the job in the global region, which is the default.
+	# region = "global"
+
+	# Specify the datacenters within the region this job can run in.
+	datacenters = ["dc1"]
+
+	# Service type jobs optimize for long-lived services. This is
+	# the default but we can change to batch for short-lived tasks.
+	# type = "service"
+
+	# Priority controls our access to resources and scheduling priority.
+	# This can be 1 to 100, inclusively, and defaults to 50.
+	# priority = 50
+
+	# Restrict our job to only linux. We can specify multiple
+	# constraints as needed.
+	constraint {
+		attribute = "${attr.kernel.name}"
+		value = "linux"
+	}
+
+	# Configure the job to do rolling updates
+	update {
+		# Stagger updates every 10 seconds
+		stagger = "10s"
+
+		# Update a single task at a time
+		max_parallel = 1
+	}
+
+	# Create a 'cache' group. Each task in the group will be
+	# scheduled onto the same machine.
+	group "cache" {
+		# Control the number of instances of this groups.
+		# Defaults to 1
+		# count = 1
+
+		# Configure the restart policy for the task group. If not provided, a
+		# default is used based on the job type.
+		restart {
+			# The number of attempts to run the job within the specified interval.
+			attempts = 10
+			interval = "5m"
+			
+			# A delay between a task failing and a restart occurring.
+			delay = "25s"
+
+			# Mode controls what happens when a task has restarted "attempts"
+			# times within the interval. "delay" mode delays the next restart
+			# till the next interval. "fail" mode does not restart the task if
+			# "attempts" has been hit within the interval.
+			mode = "delay"
+		}
+
+		# Define a task to run
+		task "nginx" {
+			# Use Docker to run the task.
+			driver = "docker"
+
+			# Configure Docker driver with the image
+			config {
+				image = "nginx:latest"
+			}
+
+			# We must specify the resources required for
+			# this task to ensure it runs on a machine with
+			# enough capacity.
+			resources {
+				cpu = 500 # 500 Mhz
+				memory = 256 # 256MB
+			}
+
+			scaling "cpu" {
+				enabled = true
+				min     = 100
+				max     = 600
+
+				policy {
+				# ...
+				}
+			}
+
+			scaling "mem" {
+				enabled = true
+				min     = 64
+				max     = 512
+
+				policy {
+				# ...
+				}
+			}
+
+			# The artifact block can be specified one or more times to download
+			# artifacts prior to the task being started. This is convenient for
+			# shipping configs or data needed by the task.
+			# artifact {
+			#	  source = "http://foo.com/artifact.tar.gz"
+			#	  options {
+			#	      checksum = "md5:c4aa853ad2215426eb7d70a21922e794"
+			#     }
+			# }
+			
+			# Specify configuration related to log rotation
+			# logs {
+			#     max_files = 10
+			#	  max_file_size = 15
+			# }
+			 
+			# Controls the timeout between signalling a task it will be killed
+			# and killing the task. If not set a default is used.
+			# kill_timeout = "20s"
+		}
+	}
+}


### PR DESCRIPTION
The [Nomad-Autoscaler](https://developer.hashicorp.com/nomad/tools/autoscaling) is changing resources based on policies.
The will lead to reconciliations back to the original values.
If an scaling policy is configured, we want to ignore changes to the respective resource:
- Horizontal scaling:
   - TaskGroup scaling block - changes `count` of TaskGroup
- Vertical scaling
   - Task scaling block(s) - changes `CPU` and `Memory` of Tasks

See #21  